### PR TITLE
Payload Extender, water and payload track material changes, fixed camera jitter

### DIFF
--- a/Assets/Materials/Custom Shaders/Custom Shader Materials/water.mat
+++ b/Assets/Materials/Custom Shaders/Custom Shader Materials/water.mat
@@ -90,38 +90,38 @@ Material:
     - _ClearCoatSmoothness: 0
     - _Cull: 2
     - _Cutoff: 0.5
-    - _DepthStrength: 0.096
-    - _Depth_Value: 4.47
+    - _DepthStrength: 0.04
+    - _Depth_Value: 5
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 10
     - _EnvironmentReflections: 1
     - _FoamNoiseScale: 40
-    - _Foam_Amount: 40
+    - _Foam_Amount: 100
     - _Foam_Cutoff: 15
-    - _Foam_Scale: 40
+    - _Foam_Scale: 100
     - _Foam_Speed: 0.005
-    - _Gloss: 0.8
+    - _Gloss: 0.75
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
     - _Metallic: 0
-    - _NoiseScale: 100
-    - _Normal_Strength: 0.5
+    - _NoiseScale: 300
+    - _Normal_Strength: 0.8
     - _OcclusionStrength: 1
     - _Parallax: 0.005
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _RippleDissolve: 3.3
-    - _RippleScale: 30
-    - _RippleSpeed: 0.1
+    - _RippleDissolve: 3.96
+    - _RippleScale: 90
+    - _RippleSpeed: 0.75
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 5
     - _Surface: 1
-    - _WaveScale: 0.5
+    - _WaveScale: -0.2
     - _WorkflowMode: 0
     - _ZTest: 4
     - _ZWrite: 1
@@ -129,22 +129,22 @@ Material:
     - _foam_Offset: 0.5
     - _scale: 2.5
     - _strenght: 0.079
-    - _transparency: 0.983
+    - _transparency: 0.75
     m_Colors:
-    - _BaseColor: {r: 0.25583112, g: 0.20518869, b: 0.5, a: 1}
+    - _BaseColor: {r: 0.2887358, g: 0.1959416, b: 0.6037736, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _DeepWaterColor: {r: 0.38324094, g: 0.12949444, b: 0.7075472, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Foam_Color: {r: 0.51911384, g: 0.42947668, b: 0.6037736, a: 1}
     - _Foam_Distortion: {r: 0.2, g: -0.7, b: 0, a: 0}
     - _Noise_Distortion: {r: 0.25, g: 0.5, b: 0, a: 0}
-    - _NormalOffsetSpeed: {r: 0.01, g: 0.05, b: 0, a: 0}
+    - _NormalOffsetSpeed: {r: 0.0015, g: 0.0015, b: 0, a: 0}
     - _NormalSpeed: {r: 0.03, g: 0.02, b: 0, a: 0}
     - _RippleColor: {r: 0.30588236, g: 0.57672095, b: 0.8, a: 1}
     - _RippleDistortion: {r: 1.31, g: 3, b: 0, a: 0}
-    - _RippleOffsetSpeed: {r: 0.01, g: 0.02, b: 0, a: 0}
+    - _RippleOffsetSpeed: {r: 0.0015, g: 0.0015, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _SpecularColor: {r: 0.14150941, g: 0.12836926, b: 0.12735847, a: 1}
+    - _SpecularColor: {r: 0.5785049, g: 0.395016, b: 0.7169812, a: 1}
     - _WaveScale: {r: 5.6, g: 8.85, b: 0, a: 0}
     - _Wave_Scale: {r: 3.21, g: 19.02, b: 2.83, a: 0}
   m_BuildTextureStacks: []

--- a/Assets/Materials/Payload/trainTrack_rails2.mat
+++ b/Assets/Materials/Payload/trainTrack_rails2.mat
@@ -23,8 +23,8 @@ Material:
   m_Name: trainTrack_rails2
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
   m_ValidKeywords:
-  - _METALLICSPECGLOSSMAP
   - _NORMALMAP
+  - _SPECULAR_SETUP
   m_InvalidKeywords:
   - _METALLICGLOSSMAP
   m_LightmapFlags: 4
@@ -39,10 +39,10 @@ Material:
     m_TexEnvs:
     - _BaseMap:
         m_Texture: {fileID: 2800000, guid: 6518b18c2faf64145b71694e5ac4e882, type: 3}
-        m_Scale: {x: 1, y: 1}
+        m_Scale: {x: 0.5, y: 10}
         m_Offset: {x: 0, y: 0}
     - _BumpMap:
-        m_Texture: {fileID: 2800000, guid: 7570ae6354a946c4190cbf7c36933b92, type: 3}
+        m_Texture: {fileID: 2800000, guid: e182ac5d3b797044fb29f3fa2acc3708, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:
@@ -63,7 +63,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: 6518b18c2faf64145b71694e5ac4e882, type: 3}
-        m_Scale: {x: 1, y: 1}
+        m_Scale: {x: 0.5, y: 10}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
         m_Texture: {fileID: 2800000, guid: 130c8d80e22ed8b44a6726c3ef26d138, type: 3}
@@ -97,7 +97,7 @@ Material:
     m_Floats:
     - _AlphaClip: 0
     - _Blend: 0
-    - _BumpScale: 1
+    - _BumpScale: 0.15
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
     - _Cull: 2
@@ -115,17 +115,17 @@ Material:
     - _Parallax: 0.02
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _Smoothness: 0.227
+    - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _Surface: 0
     - _UVSec: 0
-    - _WorkflowMode: 1
+    - _WorkflowMode: 0
     - _ZWrite: 1
     m_Colors:
-    - _BaseColor: {r: 0.29245278, g: 0.22531736, b: 0.22531736, a: 1}
-    - _Color: {r: 0.29245275, g: 0.22531733, b: 0.22531733, a: 1}
+    - _BaseColor: {r: 0.3018868, g: 0.16180691, b: 0.08657884, a: 1}
+    - _Color: {r: 0.30188674, g: 0.16180688, b: 0.086578794, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _SpecColor: {r: 0.28662154, g: 0.20697756, b: 0.3207547, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Prefabs/Player Prefabs/Camera Prefab.prefab
+++ b/Assets/Prefabs/Player Prefabs/Camera Prefab.prefab
@@ -1,5 +1,85 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &973947481901619811
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 973947481901619820}
+  - component: {fileID: 973947481901619823}
+  - component: {fileID: 973947481901619822}
+  - component: {fileID: 973947481901619817}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &973947481901619820
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 973947481901619811}
+  m_LocalRotation: {x: -0.40894908, y: -0.020471545, z: 0.013572634, w: 0.9122266}
+  m_LocalPosition: {x: -487.4628, y: 572.0939, z: 610.7799}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8686396540027233170}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &973947481901619823
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 973947481901619811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &973947481901619822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 973947481901619811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 3
+  m_FollowOffset: {x: -0.004852295, y: 23.80428, z: -7.932251}
+  m_XDamping: 0.2
+  m_YDamping: 0.2
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0.1
+  m_YawDamping: 0
+  m_RollDamping: 3
+  m_AngularDamping: 0
+--- !u!114 &973947481901619817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 973947481901619811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e8b78ac948f05a46a6d8339a503172b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2111597916701207221
 GameObject:
   m_ObjectHideFlags: 0
@@ -25,8 +105,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2111597916701207221}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -439.88458, y: -18.160881, z: 791.29724}
-  m_LocalScale: {x: 1.88445, y: 1.88445, z: 1.88445}
+  m_LocalPosition: {x: -439.8846, y: -18.160896, z: 791.29724}
+  m_LocalScale: {x: 1.8844502, y: 1.88445, z: 1.8844502}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6641255334150209832}
@@ -45,11 +125,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   player: {fileID: 0}
-  smoothSpeed: 0.125
+  smoothSpeed: 10
   rotationSpeed: 0
   backwardOffset: 5
-  upwardOffset: 2
-  xRotation: 0
+  upwardOffset: 15
+  xRotation: 8
 --- !u!1 &2707864860238914278
 GameObject:
   m_ObjectHideFlags: 0
@@ -61,7 +141,7 @@ GameObject:
   - component: {fileID: 2707864860238914281}
   - component: {fileID: 2707864860238914282}
   - component: {fileID: 2707864860238914283}
-  - component: {fileID: 2707864860238914284}
+  - component: {fileID: 552042675356648710}
   m_Layer: 0
   m_Name: cm
   m_TagString: Untagged
@@ -81,7 +161,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8686396540027233170}
+  m_Father: {fileID: 8188467551553057206}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2707864860238914282
@@ -110,15 +190,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_BindingMode: 3
   m_FollowOffset: {x: -0.004852295, y: 23.80428, z: -7.932251}
-  m_XDamping: 0.2
-  m_YDamping: 0.2
-  m_ZDamping: 1
+  m_XDamping: 0
+  m_YDamping: 0
+  m_ZDamping: 0
   m_AngularDampingMode: 0
-  m_PitchDamping: 0.1
+  m_PitchDamping: 0
   m_YawDamping: 0
-  m_RollDamping: 3
+  m_RollDamping: 0
   m_AngularDamping: 0
---- !u!114 &2707864860238914284
+--- !u!114 &552042675356648710
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -127,89 +207,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 2707864860238914278}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e8b78ac948f05a46a6d8339a503172b, type: 3}
+  m_Script: {fileID: 11500000, guid: a4c41ac9245b87c4192012080077d830, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &3438871385543359872
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3438871385543359887}
-  - component: {fileID: 3438871385543359884}
-  - component: {fileID: 3438871385543359885}
-  - component: {fileID: 2231307942286706954}
-  m_Layer: 0
-  m_Name: cm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3438871385543359887
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3438871385543359872}
-  m_LocalRotation: {x: -0.40894908, y: -0.020471545, z: 0.013572634, w: 0.9122266}
-  m_LocalPosition: {x: -487.4628, y: 572.0939, z: 610.7799}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8188467551553057206}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &3438871385543359884
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3438871385543359872}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &3438871385543359885
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3438871385543359872}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_BindingMode: 3
-  m_FollowOffset: {x: -0.004852295, y: 23.80428, z: -7.932251}
-  m_XDamping: 0.1
-  m_YDamping: 0.1
-  m_ZDamping: 0
-  m_AngularDampingMode: 0
-  m_PitchDamping: 0.1
-  m_YawDamping: 0
-  m_RollDamping: 0
-  m_AngularDamping: 0
---- !u!114 &2231307942286706954
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3438871385543359872}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e8b78ac948f05a46a6d8339a503172b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Damping: 0
 --- !u!1 &4804929455495015931
 GameObject:
   m_ObjectHideFlags: 0
@@ -234,7 +235,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4804929455495015931}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -256,9 +257,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mainCameraTransform: {fileID: 615208604654423214}
-  panSpeed: 3
-  xMaxPan: 5
-  zMaxPan: 5
+  panSpeed: 4
+  xMaxPan: 10
+  zMaxPan: 10
+  xPanThreshold: 2.5
+  zPanThreshold: 2.5
   mousePosition: {x: 0, y: 0, z: 0}
   xPan: 0
   zPan: 0
@@ -290,7 +293,7 @@ Transform:
   m_GameObject: {fileID: 5227594074343222330}
   m_LocalRotation: {x: 0.5735764, y: -0, z: -0, w: 0.8191521}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.5000006, y: 1.4999999, z: 1.5}
+  m_LocalScale: {x: 1.5000007, y: 1.5000001, z: 1.5000001}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 615208604654423214}
@@ -439,7 +442,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6848859525761625910}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -439.88943, y: 5.643402, z: 783.365}
+  m_LocalPosition: {x: -439.88947, y: 5.643387, z: 783.365}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -508,11 +511,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8188467551553057193}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -439.88943, y: 5.643402, z: 783.365}
+  m_LocalPosition: {x: -439.88947, y: 5.643387, z: 783.365}
   m_LocalScale: {x: 1.5000002, y: 1.4999998, z: 1.4999999}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3438871385543359887}
+  - {fileID: 2707864860238914281}
   m_Father: {fileID: 8686396538485887763}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -533,7 +536,7 @@ MonoBehaviour:
   m_LockStageInInspector: 
   m_StreamingVersion: 20170927
   m_Priority: 2
-  m_StandbyUpdate: 2
+  m_StandbyUpdate: 0
   m_LookAt: {fileID: 0}
   m_Follow: {fileID: 2111597916701207226}
   m_Lens:
@@ -553,7 +556,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls: []
   m_LegacyBlendHint: 0
-  m_ComponentOwner: {fileID: 3438871385543359887}
+  m_ComponentOwner: {fileID: 2707864860238914281}
 --- !u!114 &5227594074370000447
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -667,11 +670,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8686396540027233169}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -439.88943, y: 5.643402, z: 783.365}
+  m_LocalPosition: {x: -439.88947, y: 5.643387, z: 783.365}
   m_LocalScale: {x: 1.5000002, y: 1.4999998, z: 1.4999999}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2707864860238914281}
+  - {fileID: 973947481901619820}
   m_Father: {fileID: 8686396538485887763}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -712,7 +715,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls: []
   m_LegacyBlendHint: 0
-  m_ComponentOwner: {fileID: 2707864860238914281}
+  m_ComponentOwner: {fileID: 973947481901619820}
 --- !u!114 &8686396540027233172
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Rooms/Refined Rooms/Alchemy Lab - Refined.prefab
+++ b/Assets/Prefabs/Rooms/Refined Rooms/Alchemy Lab - Refined.prefab
@@ -3073,6 +3073,7 @@ Transform:
   - {fileID: 3263208655251443581}
   - {fileID: 7687167268253343677}
   - {fileID: 3610241835632607464}
+  - {fileID: 5497820897750140869}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -13652,6 +13653,196 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 1655419095541406373, guid: 4cdc12872d4485349a99096e8cd802da, type: 3}
   m_PrefabInstance: {fileID: 4196638854396058644}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6263809732113745578
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2861502042951025894}
+    m_Modifications:
+    - target: {fileID: 1919003181671219555, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_Name
+      value: CameraRotationTrigger (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: camFollow
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: angleOffset
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: mainVirtualCam
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotateDuration
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useCamStartAngleAsExit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useTriggerAsAngleOffset
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].time
+      value: 0.008250736
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].time
+      value: 0.40290105
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].time
+      value: 0.97198486
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].time
+      value: 0.9656026
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].value
+      value: 0.005058348
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].value
+      value: 0.5873217
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].value
+      value: 1.012146
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].value
+      value: 0.99030644
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].inSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inWeight
+      value: 0.33333334
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outWeight
+      value: 0.057946987
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outWeight
+      value: 0.074752174
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outWeight
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 45.7277
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 4.517687
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+--- !u!4 &5497820897750140869 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+  m_PrefabInstance: {fileID: 6263809732113745578}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6320682870075472808
 PrefabInstance:

--- a/Assets/Prefabs/Rooms/Refined Rooms/Altar Room.prefab
+++ b/Assets/Prefabs/Rooms/Refined Rooms/Altar Room.prefab
@@ -46505,6 +46505,7 @@ Transform:
   - {fileID: 302000253678503667}
   - {fileID: 268618234643090853}
   - {fileID: 5305061421410103854}
+  - {fileID: 3545768198594859945}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -53647,6 +53648,204 @@ MonoBehaviour:
 Transform:
   m_CorrespondingSourceObject: {fileID: 3650638188812647480, guid: a2a060732547fe64581bb0cb3c2bdf1d, type: 3}
   m_PrefabInstance: {fileID: 2305916665343457874}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3140330940258325190
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2305916664375433980}
+    m_Modifications:
+    - target: {fileID: 1919003181671219555, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_Name
+      value: CameraRotationTrigger (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219560, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useColliderScale
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: camFollow
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: angleOffset
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: mainVirtualCam
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotateDuration
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useCamStartAngleAsExit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useTriggerAsAngleOffset
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].time
+      value: 0.008250736
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].time
+      value: 0.40290105
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].time
+      value: 0.97198486
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].time
+      value: 0.9656026
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].value
+      value: 0.005058348
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].value
+      value: 0.5873217
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].value
+      value: 1.012146
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].value
+      value: 0.99030644
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].inSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inWeight
+      value: 0.33333334
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outWeight
+      value: 0.057946987
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outWeight
+      value: 0.074752174
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outWeight
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_RootOrder
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 11.59647
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 4.2742662
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 4.517687
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.82
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+--- !u!4 &3545768198594859945 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+  m_PrefabInstance: {fileID: 3140330940258325190}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3185858343593254465
 PrefabInstance:

--- a/Assets/Prefabs/Rooms/Refined Rooms/Garden - Refined.prefab
+++ b/Assets/Prefabs/Rooms/Refined Rooms/Garden - Refined.prefab
@@ -35828,6 +35828,7 @@ Transform:
   - {fileID: 1469488746537198350}
   - {fileID: 3998664591689956386}
   - {fileID: 1278918736}
+  - {fileID: 5460007574921074441}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -40307,4 +40308,194 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 7461181260609055295, guid: da77e1c985ab4f34697f2cc54f3084ca, type: 3}
   m_PrefabInstance: {fileID: 5833688266397439517}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5864949847274509926
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1885216342541790051}
+    m_Modifications:
+    - target: {fileID: 1919003181671219555, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_Name
+      value: CameraRotationTrigger (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: camFollow
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: angleOffset
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: mainVirtualCam
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotateDuration
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useCamStartAngleAsExit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useTriggerAsAngleOffset
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].time
+      value: 0.008250736
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].time
+      value: 0.40290105
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].time
+      value: 0.97198486
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].time
+      value: 0.9656026
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].value
+      value: 0.005058348
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].value
+      value: 0.5873217
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].value
+      value: 1.012146
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].value
+      value: 0.99030644
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].inSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inWeight
+      value: 0.33333334
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outWeight
+      value: 0.057946987
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outWeight
+      value: 0.074752174
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outWeight
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 16.214981
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 4.517687
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.66
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.999995
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.0031654239
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.363
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+--- !u!4 &5460007574921074441 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+  m_PrefabInstance: {fileID: 5864949847274509926}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Rooms/Refined Rooms/Graveyard - Refined.prefab
+++ b/Assets/Prefabs/Rooms/Refined Rooms/Graveyard - Refined.prefab
@@ -36140,6 +36140,7 @@ Transform:
   - {fileID: 1763511381127647297}
   - {fileID: 6765290685231885460}
   - {fileID: 1973404313}
+  - {fileID: 5758548500397828479}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -42767,6 +42768,192 @@ MeshCollider:
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: fd3f60e50c7e1cc44b2377b395625241, type: 3}
   m_PrefabInstance: {fileID: 4947677674832691721}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6146237426945337360
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8438866393923493089}
+    m_Modifications:
+    - target: {fileID: 1919003181671219555, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_Name
+      value: CameraRotationTrigger (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: camFollow
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: angleOffset
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: mainVirtualCam
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotateDuration
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useCamStartAngleAsExit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useTriggerAsAngleOffset
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].time
+      value: 0.008250736
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].time
+      value: 0.40290105
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].time
+      value: 0.97198486
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].time
+      value: 0.9656026
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].value
+      value: 0.005058348
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].value
+      value: 0.5873217
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].value
+      value: 1.012146
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].value
+      value: 0.99030644
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].inSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inWeight
+      value: 0.33333334
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outWeight
+      value: 0.057946987
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outWeight
+      value: 0.074752174
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outWeight
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 4.517687
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+--- !u!4 &5758548500397828479 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+  m_PrefabInstance: {fileID: 6146237426945337360}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8438866393062028957
 PrefabInstance:

--- a/Assets/Prefabs/Rooms/Refined Rooms/Library - Refined.prefab
+++ b/Assets/Prefabs/Rooms/Refined Rooms/Library - Refined.prefab
@@ -31236,6 +31236,7 @@ Transform:
   - {fileID: 184933074}
   - {fileID: 176182411}
   - {fileID: 2072264173324773800}
+  - {fileID: 6703849270512911415}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -43206,6 +43207,196 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 1695121731876021521, guid: df49277408417af44ac4e0cf7b2e3d27, type: 3}
   m_PrefabInstance: {fileID: 3881129831655533856}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5163781994285663576
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2475505621797937951}
+    m_Modifications:
+    - target: {fileID: 1919003181671219555, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_Name
+      value: CameraRotationTrigger (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: camFollow
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: angleOffset
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: mainVirtualCam
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotateDuration
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useCamStartAngleAsExit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useTriggerAsAngleOffset
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].time
+      value: 0.008250736
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].time
+      value: 0.40290105
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].time
+      value: 0.97198486
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].time
+      value: 0.9656026
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].value
+      value: 0.005058348
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].value
+      value: 0.5873217
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].value
+      value: 1.012146
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].value
+      value: 0.99030644
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].inSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inWeight
+      value: 0.33333334
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outWeight
+      value: 0.057946987
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outWeight
+      value: 0.074752174
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outWeight
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 22.087894
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 4.517687
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+--- !u!4 &6703849270512911415 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+  m_PrefabInstance: {fileID: 5163781994285663576}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5939837002330012454
 PrefabInstance:

--- a/Assets/Prefabs/Rooms/Refined Rooms/Winery - Refined.prefab
+++ b/Assets/Prefabs/Rooms/Refined Rooms/Winery - Refined.prefab
@@ -1773,6 +1773,7 @@ Transform:
   - {fileID: 84934857028299403}
   - {fileID: 438955194}
   - {fileID: 5385190715702197127}
+  - {fileID: 2165205134090680457}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2197,6 +2198,196 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 8912054329319863084, guid: 9c5c6d7a84acba7488e885399826a486, type: 3}
   m_PrefabInstance: {fileID: 45147110238364579}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &337191220730673638
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8973182847692497422}
+    m_Modifications:
+    - target: {fileID: 1919003181671219555, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_Name
+      value: CameraRotationTrigger (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: camFollow
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: angleOffset
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: mainVirtualCam
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotateDuration
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useCamStartAngleAsExit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: useTriggerAsAngleOffset
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].time
+      value: 0.008250736
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].time
+      value: 0.40290105
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].time
+      value: 0.97198486
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].time
+      value: 0.9656026
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].value
+      value: 0.005058348
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].value
+      value: 0.5873217
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].value
+      value: 1.012146
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].value
+      value: 0.99030644
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].inSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outSlope
+      value: -0.716408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].inWeight
+      value: 0.33333334
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outSlope
+      value: 2.6470232
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].inWeight
+      value: 0.15701196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[3].outSlope
+      value: -0.0268789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[0].outWeight
+      value: 0.057946987
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[1].outWeight
+      value: 0.074752174
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219561, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: rotationCurve.m_CurveMax.m_Curve.Array.data[2].outWeight
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 18.891579
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 4.517687
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+--- !u!4 &2165205134090680457 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1919003181671219567, guid: 7518309fa200cce4db1b54870d875392, type: 3}
+  m_PrefabInstance: {fileID: 337191220730673638}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1180232077292825063
 PrefabInstance:

--- a/Assets/Prefabs/Weapons/Grenade.prefab
+++ b/Assets/Prefabs/Weapons/Grenade.prefab
@@ -189,7 +189,7 @@ MonoBehaviour:
     m_DissipationMode: 2
     m_DissipationDistance: 40
     m_PropagationSpeed: 250
-  m_DefaultVelocity: {x: 0.075, y: 0.075, z: 0.075}
+  m_DefaultVelocity: {x: 1, y: 0.1, z: 0.1}
 --- !u!1 &5384791875004284638
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/camera/CameraRotationTrigger.prefab
+++ b/Assets/Prefabs/camera/CameraRotationTrigger.prefab
@@ -73,6 +73,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   camFollow: {fileID: 0}
+  mainVirtualCam: {fileID: 0}
   useTriggerAsAngleOffset: 0
   angleOffset: 45
   rotateDuration: 1
@@ -149,3 +150,4 @@ MonoBehaviour:
     m_ConstantMax: 0
   previousRotationAngle: 0
   AlignmentBetweenCamAndTrigger: 0
+  shouldDestroy: 0

--- a/Assets/Scenes/Test Scenes/Player Scenes/Player Dashing.unity
+++ b/Assets/Scenes/Test Scenes/Player Scenes/Player Dashing.unity
@@ -1152,7 +1152,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Camera Prefab
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 2231307942286706954, guid: f3990bf153491e7469dd6749ff621748, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: f3990bf153491e7469dd6749ff621748, type: 3}
 --- !u!114 &1313563216 stripped
 MonoBehaviour:
@@ -1778,6 +1779,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e162c6d91905a8e49a7f35b06bacec76, type: 3}
+--- !u!1 &1978576133 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3438871385543359872, guid: f3990bf153491e7469dd6749ff621748, type: 3}
+  m_PrefabInstance: {fileID: 1229552892}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1978576138
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1978576133}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4c41ac9245b87c4192012080077d830, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Damping: 0
 --- !u!1 &2011091960
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Payload/Payload.cs
+++ b/Assets/Scripts/Payload/Payload.cs
@@ -24,7 +24,8 @@ public class Payload : MonoBehaviour, IDamagable
 
     [SerializeField] GameObject lootbox;
     float stopTimer = 0f;
-    public float InteractionRange { get => interactionRange; }
+    public float InteractionRange { get => interactionRange;}
+    public float PlayerRange { get => playerRange; set => playerRange = value; }
     [SerializeField][Range(0.1f, 0.9f)] float enemySlowSpeed = 0.5f;
     [SerializeField][Range(0.1f, 0.9f)] float playerSlowSpeed = 0.5f;
     [SerializeField] GameObject visualEffects;

--- a/Assets/Scripts/Payload/PayloadExtender.cs
+++ b/Assets/Scripts/Payload/PayloadExtender.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PayloadExtender : MonoBehaviour
+{
+    [SerializeField] float extendedPlayerRange;
+    
+    float originalPlayerRange;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if(other.GetComponent<Payload>() != null)
+        {
+            Payload payload = other.GetComponent<Payload>();
+            originalPlayerRange = originalPlayerRange==0 ? payload.PlayerRange:originalPlayerRange;
+            payload.PlayerRange = extendedPlayerRange;
+        }
+
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.GetComponent<Payload>() != null)
+        {
+            Payload payload = other.GetComponent<Payload>();
+            payload.PlayerRange = originalPlayerRange!=0 ? originalPlayerRange : payload.PlayerRange;
+            originalPlayerRange = 0;
+        }
+    }
+
+ 
+}

--- a/Assets/Scripts/Payload/PayloadExtender.cs.meta
+++ b/Assets/Scripts/Payload/PayloadExtender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bc5bc35b4684e44e9acd4b39035cc7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/CameraFocus.cs
+++ b/Assets/Scripts/Player/CameraFocus.cs
@@ -27,7 +27,7 @@ public class CameraFocus : MonoBehaviour
         Vector3 backOffset = forwardDirection * backwardOffset;
         offset = new Vector3(-backOffset.x, -backOffset.y + upwardOffset, -backOffset.z);
         Vector3 desiredPosition = player.position + offset;
-        Vector3 smoothedPosition = Vector3.Lerp(transform.position, desiredPosition, smoothSpeed);
+        Vector3 smoothedPosition = Vector3.Lerp(transform.position, desiredPosition, smoothSpeed * Time.fixedDeltaTime);
         transform.position = smoothedPosition;
     }
 
@@ -54,7 +54,7 @@ public class CameraFocus : MonoBehaviour
             Vector3 direction = (point - transform.position).normalized;
             direction.y = 0;
             Quaternion toRotation = Quaternion.LookRotation(direction, Vector3.up);
-            transform.rotation = Quaternion.RotateTowards(transform.rotation, toRotation, rotationSpeed * Time.deltaTime);
+            transform.rotation = Quaternion.Slerp(transform.rotation, toRotation, rotationSpeed * Time.deltaTime);
         }
     }
 }

--- a/Assets/Scripts/Player/CameraMousePanning.cs
+++ b/Assets/Scripts/Player/CameraMousePanning.cs
@@ -18,7 +18,7 @@ public class CameraMousePanning : MonoBehaviour
     [SerializeField] float zPan;
 
 
-    void Update()
+    void FixedUpdate()
     {
         PanCameraWithMouse();
     }
@@ -35,16 +35,14 @@ public class CameraMousePanning : MonoBehaviour
         float currentXPan = Mathf.Lerp(-xMaxPan, xMaxPan, xPercentageValue);
         float currentZPan = Mathf.Lerp(-zMaxPan, zMaxPan, zPercentageValue);
 
-        interpolatedXPan = Mathf.Lerp(interpolatedXPan, Mathf.Abs(currentXPan) > xPanThreshold ? currentXPan : 0, Time.deltaTime * panSpeed);
-interpolatedZPan = Mathf.Lerp(interpolatedZPan, Mathf.Abs(currentZPan) > zPanThreshold ? currentZPan : 0, Time.deltaTime * panSpeed);
-
-        
+        interpolatedXPan = Mathf.Lerp(interpolatedXPan, Mathf.Abs(currentXPan) > xPanThreshold ? currentXPan : 0, Time.fixedDeltaTime * panSpeed);
+        interpolatedZPan = Mathf.Lerp(interpolatedZPan, Mathf.Abs(currentZPan) > zPanThreshold ? currentZPan : 0, Time.fixedDeltaTime * panSpeed);
 
         xPan = currentXPan;
         zPan = currentZPan;
 
         Vector3 newPosition = new Vector3(interpolatedXPan,0,interpolatedZPan);
 
-        transform.localPosition = newPosition;
+        mainCameraTransform.localPosition = newPosition;
     }
 }

--- a/Assets/Scripts/misc scripts/RotateCameraOnTrigger.cs
+++ b/Assets/Scripts/misc scripts/RotateCameraOnTrigger.cs
@@ -7,20 +7,39 @@ using Cinemachine;
 public class RotateCameraOnTrigger : MonoBehaviour
 {
     [SerializeField] Transform camFollow;
-    [SerializeField] CinemachineVirtualCamera mainVirtualCam;
     [Header("Camera Rotation Settings")]
     [SerializeField] bool useTriggerAsAngleOffset;
+    [SerializeField] bool useCamStartAngleAsExit = true;
     [SerializeField] float angleOffset;
+    
     [SerializeField] float rotateDuration;
     [SerializeField] MinMaxCurve rotationCurve;
 
     [Header("Debug Stats")]
-    [SerializeField] float previousRotationAngle;
+    [SerializeField] float? previousRotationAngle = null;
     [SerializeField] float AlignmentBetweenCamAndTrigger;
+    [SerializeField] float startAngle;
     float previosuXDamping;
 
     [SerializeField] bool shouldDestroy;
 
+
+    private void Start()
+    {
+        if (camFollow == null)
+        {
+            camFollow = FindObjectOfType<CameraFocus>().transform;
+        }
+
+        Invoke("GetStartAngle", 1.5f);
+     
+
+    }
+
+    void GetStartAngle()
+    {
+        startAngle = camFollow.transform.eulerAngles.y;
+    }
 
     private void OnValidate()
     {
@@ -31,11 +50,6 @@ public class RotateCameraOnTrigger : MonoBehaviour
         }
     }
 
-    private void Start()
-    {
-        previosuXDamping = mainVirtualCam.GetCinemachineComponent<CinemachineTransposer>().m_XDamping;
-    }
-
     private void OnTriggerExit(Collider other)
     {
         if (camFollow == null) return;
@@ -44,9 +58,8 @@ public class RotateCameraOnTrigger : MonoBehaviour
             Vector3 directionFromCamera = (camFollow.transform.position - transform.position).normalized;
             AlignmentBetweenCamAndTrigger = Vector3.Dot(transform.forward, directionFromCamera);
             StopAllCoroutines();
-            mainVirtualCam.GetCinemachineComponent<CinemachineTransposer>().m_XDamping = 0;
-
-            if (AlignmentBetweenCamAndTrigger > 0.015f) // you never know when these stupid edge casses happen so i just put a small value above 0
+           
+            if (AlignmentBetweenCamAndTrigger > 0.1f && previousRotationAngle==null ) // you never know when these stupid edge casses happen so i just put a small value above 0
             {
                 previousRotationAngle = camFollow.transform.eulerAngles.y;
                 float targetAngleOffset = useTriggerAsAngleOffset ? transform.rotation.eulerAngles.y : angleOffset;
@@ -57,30 +70,29 @@ public class RotateCameraOnTrigger : MonoBehaviour
                 }
                 return;
             }
-            StartCoroutine(RotateCamera(previousRotationAngle));
+            float resetAngle = useCamStartAngleAsExit ? startAngle : (float)previousRotationAngle;
+            StartCoroutine(RotateCamera(resetAngle));
+            previousRotationAngle = null;
 
         }
 
     }
 
 
-    void ResetCameraDamping()
-    {
-        mainVirtualCam.GetCinemachineComponent<CinemachineTransposer>().m_XDamping = previosuXDamping;
-    }
+  
 
-    IEnumerator RotateCamera(float angle)
+    IEnumerator RotateCamera(float? angle)
     {
         float timer = 0;
-        float randomValue = Random.value;
+        float randomValue = rotationCurve.mode == ParticleSystemCurveMode.TwoConstants ? Random.value : 0;
         float currentAngle = camFollow.transform.eulerAngles.y;
+      
         while (timer < rotateDuration)
         {
             timer += Time.deltaTime;
             float t = rotationCurve.Evaluate(timer / rotateDuration, randomValue);
-            camFollow.transform.eulerAngles = new Vector3(camFollow.transform.eulerAngles.x, Mathf.LerpAngle(currentAngle, angle, t), camFollow.transform.eulerAngles.z);
+            camFollow.transform.eulerAngles = new Vector3(camFollow.transform.eulerAngles.x, Mathf.LerpAngle(currentAngle, (float)angle, t), camFollow.transform.eulerAngles.z);
             yield return null;
         }
-        Invoke(nameof(ResetCameraDamping), 1f);
     }
 }

--- a/Assets/Settings/High_PipelineAsset.asset
+++ b/Assets/Settings/High_PipelineAsset.asset
@@ -34,7 +34,7 @@ MonoBehaviour:
   m_MainLightShadowsSupported: 1
   m_MainLightShadowmapResolution: 2048
   m_AdditionalLightsRenderingMode: 1
-  m_AdditionalLightsPerObjectLimit: 2
+  m_AdditionalLightsPerObjectLimit: 8
   m_AdditionalLightShadowsSupported: 1
   m_AdditionalLightsShadowmapResolution: 2048
   m_AdditionalLightsShadowResolutionTierLow: 256
@@ -55,7 +55,7 @@ MonoBehaviour:
   m_ConservativeEnclosingSphere: 0
   m_NumIterationsEnclosingSphere: 64
   m_AdditionalLightsCookieResolution: 2048
-  m_AdditionalLightsCookieFormat: 3
+  m_AdditionalLightsCookieFormat: 4
   m_UseSRPBatcher: 1
   m_SupportsDynamicBatching: 0
   m_MixedLightingSupported: 1

--- a/Assets/Settings/High_PipelineAsset_ForwardRenderer.asset
+++ b/Assets/Settings/High_PipelineAsset_ForwardRenderer.asset
@@ -14,8 +14,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   debugShaders:
     debugReplacementPS: {fileID: 4800000, guid: cf852408f2e174538bcd9b7fda1c5ae7, type: 3}
-  m_RendererFeatures: []
-  m_RendererFeatureMap: 
+  m_RendererFeatures:
+  - {fileID: 1232113421780383899}
+  m_RendererFeatureMap: 9bf8350ca1581911
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
   xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
@@ -46,10 +47,33 @@ MonoBehaviour:
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
-  m_RenderingMode: 0
+  m_RenderingMode: 1
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 0
-  m_AccurateGbufferNormals: 0
+  m_AccurateGbufferNormals: 1
   m_ClusteredRendering: 0
   m_TileSize: 32
   m_IntermediateTextureMode: 1
+--- !u!114 &1232113421780383899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f62c9c65cf3354c93be831c8bc075510, type: 3}
+  m_Name: ScreenSpaceAmbientOcclusion
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  m_Shader: {fileID: 4800000, guid: 0849e84e3d62649e8882e9d6f056a017, type: 3}
+  m_Settings:
+    Downsample: 1
+    AfterOpaque: 1
+    Source: 1
+    NormalSamples: 1
+    Intensity: 3
+    DirectLightingStrength: 0.25
+    Radius: 0.035
+    SampleCount: 4

--- a/Assets/Textures/Lava/noise1.png.meta
+++ b/Assets/Textures/Lava/noise1.png.meta
@@ -3,11 +3,11 @@ guid: 39a00f3a4d887cc448b5d165b19938eb
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 11
+  serializedVersion: 12
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -23,6 +23,8 @@ TextureImporter:
   isReadable: 0
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -31,12 +33,12 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 2
-    mipBias: -100
-    wrapU: -1
-    wrapV: -1
-    wrapW: -1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
   nPOTScale: 1
   lightmap: 0
   compressionQuality: 50
@@ -51,13 +53,17 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
   maxTextureSizeSet: 0
   compressionQualitySet: 0
   textureFormatSet: 0
+  ignorePngGamma: 0
   applyGammaDecoding: 0
+  cookieLightType: 1
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
@@ -107,6 +113,18 @@ TextureImporter:
     overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 1024
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
@@ -120,6 +138,7 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable: {}
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/Assets/Textures/water shader/Textures/PerlinNoise.png.meta
+++ b/Assets/Textures/water shader/Textures/PerlinNoise.png.meta
@@ -1,13 +1,13 @@
 fileFormatVersion: 2
 guid: e182ac5d3b797044fb29f3fa2acc3708
 TextureImporter:
-  fileIDToRecycleName: {}
+  internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 7
+  serializedVersion: 12
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -23,6 +23,8 @@ TextureImporter:
   isReadable: 0
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -31,12 +33,12 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
-    aniso: -1
-    mipBias: -100
-    wrapU: -1
-    wrapV: -1
-    wrapW: -1
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
   nPOTScale: 1
   lightmap: 0
   compressionQuality: 50
@@ -51,35 +53,54 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
   maxTextureSizeSet: 0
   compressionQualitySet: 0
   textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 1
+  cookieLightType: 1
   platformSettings:
-  - serializedVersion: 2
+  - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 2
+    textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-  - serializedVersion: 2
+    forceMaximumCompressionQuality_BC6H_BC7: 1
+  - serializedVersion: 3
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 2
+    textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 1
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 1
   spriteSheet:
     serializedVersion: 2
     sprites: []
@@ -87,10 +108,13 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 
+    internalID: 0
     vertices: []
     indices: 
     edges: []
     weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0


### PR DESCRIPTION
### Payload Extender (#40)
On Trigger enter of the glass bridge the payload player range increases from 45 to 70(this is configurable in inspector) and on trigger exit of the glass bridge the payload player range exists back to default which in this case will be 45

### Main Scene Changes (Payload Refactor Scene)
1. lowered the entrance y position just a bit to prevent player to get stuck
2. lowered the exit stairs of the glass bridge to prevent player from getting stuck
3. removed a collider that was blocking player movement near the end of the level 
4. updated payload track material , specular and normal map are now stronger
5. updated water shader scale and movement to be more coherent with the rest of the game scale
6. increased the max camera  panning for x and z

### Camera Panning 
1. THE JITTER IS FIXED,had to change the code from update to fixed update
2. **Note @Armaantakyar1  :** this may break certain scenes , specifically the tutorial , so in that scene the camera needs to be setup again 